### PR TITLE
Add verbose flag to test command

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const defaultGoDict = {
   // Build command - followed by bin dest and input path
   buildCmd: `go build -ldflags="-s -w" -o %2 %1`,
   // Test command - followed by value in tests array below
-  testCmd: `stage=testing GO_TEST=serverless go test %1`,
+  testCmd: `stage=testing GO_TEST=serverless go test -v %1`,
   // Path to store build results
   binPath: 'bin',
   // Runtime to require


### PR DESCRIPTION
Without this flag, fmt.Println(), t.Log(), and other calls which output to standard output are not shown.