### PR TITLE
Fixed an issue with duplicate binary in zip

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,7 +368,7 @@ class ServerlessPlugin {
       if (this.getGoConfigParam('minimizePackage') && !func.package) {
         func.package = {
           exclude: [`./**`],
-          include: [`./${func.handler}`],
+          include: [func.handler],
         }
       }
     }


### PR DESCRIPTION
If the `include` path starts with `./` the resulting zip will contain two entries for the same file: one with `./` prefix and one without