### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ class ServerlessPlugin {
             usage:
               'Not yet active: If the build should be made for the local machine (otherwise defaults to AWS deployment)',
             shortcut: 'l',
+            type: 'boolean',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessPlugin for "local"
```